### PR TITLE
Silenced Warnings, Added Features

### DIFF
--- a/CVARINFO.txt
+++ b/CVARINFO.txt
@@ -10,6 +10,7 @@ user bool 	bdoom_muzzle		= true;
 server bool bdoom_tracers		= true;
 server bool bdoom_flies			= true;
 user bool	bdoom_shadows		= true;
+user bool	bdoom_hudface		= true;
 
 
 server float fs_volume_mul = 1.0;

--- a/CVARINFO.txt
+++ b/CVARINFO.txt
@@ -1,5 +1,6 @@
 server bool bdoom_blood 		= true;
 server bool bdoom_gibs 			= true;
+server bool bdoom_bossgibs		= true;
 server bool bdoom_flames 		= true;
 server bool bdoom_debris 		= true;
 server bool bdoom_sparks 		= true;

--- a/DECORATE/BD_Blood.txt
+++ b/DECORATE/BD_Blood.txt
@@ -47,6 +47,127 @@ states
 	}
 }
 
+// This replaces blood so that the blood drop flies forward.
+// If BloodDrop replaced Blood directly, it'd just follow Blood's 
+// default behavior and fall down on the ground.
+Actor BloodSpatter : Blood replaces Blood
+{
++PUFFGETSOWNER
+-NOGRAVITY
++FORCEXYBILLBOARD
+-ALLOWPARTICLES
++THRUACTORS
+-MISSILE
+radius 1
+height 1
+mass 1
+gravity 0.5
+scale .45
+alpha .75
+states
+	{
+	Spawn:
+		TNT1 AAA 0 //overrides vanilla frame-switching/damage-dependent behavior
+		TNT1 A 0 A_SetScale(scalex*randompick(-1,1),scaley)
+		TNT1 A 0 A_JumpIf(GetCvar("bdoom_blood")==0,"Animation")
+		TNT1 A 0 A_FaceTarget
+
+		TNT1 A 0 A_JumpIf(CheckClass("BlueBloodSpatter",	AAPTR_DEFAULT),3)
+		TNT1 A 0 A_JumpIf(CheckClass("GreenBloodSpatter",	AAPTR_DEFAULT),3)
+
+		TNT1 A 0 A_SpawnItemEx("BloodDrop",16,0,		random(4,8),random(1,3),0,random(1,3),random(-150,-210),SXF_TRANSFERPOINTERS)
+		goto Animation
+		TNT1 A 0 A_SpawnItemEx("BlueBloodDrop",16,0,	random(4,8),random(1,3),0,random(1,3),random(-150,-210),SXF_TRANSFERPOINTERS)
+		goto Animation
+		TNT1 A 0 A_SpawnItemEx("GreenBloodDrop",16,0,	random(4,8),random(1,3),0,random(1,3),random(-150,-210),SXF_TRANSFERPOINTERS)
+		goto Animation
+
+	Animation:
+		BLOD ABCDEF 2 A_FadeOut(0.05)
+		stop
+	}
+}
+
+Actor BloodSpatter_Saw : BloodSpatter replaces AxeBlood
+{
++NOGRAVITY
+scale .3
+alpha .5
+states
+	{
+	Spawn:
+		TNT1 A 0 NoDelay A_SetScale(scalex*randompick(-1,1),scaley)
+		TNT1 A 0 A_JumpIf(GetCvar("bdoom_blood")==0,"Animation")
+		TNT1 A 0 A_FaceTarget
+
+		TNT1 A 0 A_JumpIf(CheckClass("BlueBloodSpatter_Saw",	AAPTR_DEFAULT),5)
+		TNT1 A 0 A_JumpIf(CheckClass("GreenBloodSpatter_Saw",	AAPTR_DEFAULT),7)
+
+		TNT1 AAA 0 A_SpawnItemEx("BloodDrop",		random(-2,2),random(-2,2),random(4,6),random(0,1),0,random(6,9),random(-150,-210),SXF_TRANSFERPOINTERS,64)
+		goto Animation
+		TNT1 AAA 0 A_SpawnItemEx("BlueBloodDrop",	random(-2,2),random(-2,2),random(4,6),random(0,1),0,random(6,9),random(-150,-210),SXF_TRANSFERPOINTERS,64)
+		goto Animation
+		TNT1 AAA 0 A_SpawnItemEx("GreenBloodDrop",	random(-2,2),random(-2,2),random(4,6),random(0,1),0,random(6,9),random(-150,-210),SXF_TRANSFERPOINTERS,64)
+		goto Animation
+	}
+}
+
+// ********************
+// Colored blood
+// ********************
+
+
+
+actor BlueBloodDrop : BloodDrop
+{
+translation "169:191=196:207", "16:31=196:207", "32:47=240:246" //"168:191=192:207","16:47=240:247"
+stencilcolor "00 00 90"
+decal CacoBloodSplat
+}
+
+actor BlueBloodSpurt : BloodSpurt
+{
+translation "169:191=196:207", "16:31=196:207", "32:47=240:246" //"168:191=192:207","16:47=240:247"
+stencilcolor "00 00 90"
+decal CacoBloodSplat
+}
+
+Actor GreenBloodDrop : BloodDrop
+{	
+translation "169:191=112:127", "16:31=152:159", "32:47=152:159"
+stencilcolor "00 80 00"
+decal BaronBloodSplat
+}
+
+actor GreenBloodSpurt : BloodSpurt
+{
+translation "169:191=112:127", "16:31=152:159", "32:47=152:159"
+stencilcolor "00 80 00"
+decal BaronBloodSplat
+}
+
+// Additional Blood Spatters for non-red blood
+
+
+Actor BlueBloodSpatter : BloodSpatter
+{
+translation "169:191=196:207", "16:31=196:207", "32:47=240:246" //"168:191=192:207","16:47=240:247"
+}
+
+Actor BlueBloodSpatter_Saw : BloodSpatter_Saw
+{
+translation "169:191=196:207", "16:31=196:207", "32:47=240:246" //"168:191=192:207","16:47=240:247"
+}
+
+Actor GreenBloodSpatter : BloodSpatter
+{
+translation "169:191=112:127", "16:31=152:159", "32:47=152:159"
+}
+
+Actor GreenBloodSpatter_Saw : BloodSpatter_Saw
+{
+translation "169:191=112:127", "16:31=152:159", "32:47=152:159"
+}
 
 
 

--- a/DECORATE/MONSTERS/Arachnotron.txt
+++ b/DECORATE/MONSTERS/Arachnotron.txt
@@ -53,10 +53,11 @@ states
 		ARAM c 3 a_noblocking
 		ARAM defgh 3 A_SpawnItemEx("BlackSmoke",random(-20,20),random(-20,20),random(16,40),0,0,1)
 		ARAM ijkl 3 A_SpawnItemEx("BlackSmoke",random(-20,20),random(-20,20),random(16,40),0,0,1)
+		TNT1 A 0 a_bossdeath
 		ARAM MMMMM 6 A_SpawnItemEx("BlackSmoke",random(-20,20),random(-20,20),random(16,40),0,0,1)
 		ARAM MMMMM 9 A_SpawnItemEx("BlackSmoke",random(-20,20),random(-20,20),random(16,40),0,0,1)
 		ARAM MMMMM 12 A_SpawnItemEx("BlackSmoke",random(-20,20),random(-20,20),random(16,40),0,0,1)
-		ARAM m -1 a_bossdeath
+		ARAM m -1
 		stop
 	Raise:
 		TNT1 A 0 A_GiveToChildren("WasGibbed",1)

--- a/DECORATE/MONSTERS/Cyberdemon.txt
+++ b/DECORATE/MONSTERS/Cyberdemon.txt
@@ -32,7 +32,8 @@ states
 		goto see
 	
 	Death:
-		TNT1 A 0 A_JumpIf(GetCVAR("bdoom_Gibs")==1,"Death.Particles")
+		TNT1 A 0 A_JumpIf(GetCVAR("bdoom_Gibs")==0,2)
+		TNT1 A 0 A_JumpIf(GetCVAR("bdoom_bossgibs")==1,"Death.Particles")
 		CBDD a 13
 		CBDD b 5 a_scream
 		CBDD cdefghij 4

--- a/DECORATE/MONSTERS/Mancubus.txt
+++ b/DECORATE/MONSTERS/Mancubus.txt
@@ -85,10 +85,11 @@ states
 		MANM cde 3
 		MANM f 3 a_noblocking
 		MANM ghijklmnop 3 A_SpawnItemEx("BlackSmoke",random(-16,16),random(-16,16),random(8,16),0,0,1)
+		TNT1 A 0 a_bossdeath
 		MANM QQQQQ 6 A_SpawnItemEx("BlackSmoke",random(-16,16),random(-16,16),random(8,16),0,0,1)
 		MANM QQQQQ 9 A_SpawnItemEx("BlackSmoke",random(-16,16),random(-16,16),random(8,16),0,0,1)
 		MANM QQQQQ 12 A_SpawnItemEx("BlackSmoke",random(-16,16),random(-16,16),random(8,16),0,0,1)
-		MANM Q -1 a_bossdeath
+		MANM Q -1
 		stop
 	Death.PlasmaDamage1:
 		TNT1 A 0 A_GiveINventory("BD_KillChecker",2)
@@ -97,10 +98,11 @@ states
 		MANO cd 4
 		MANO E 4 a_noblocking
 		MANO Fghi 4 A_SpawnItemEx("BlackSmoke",random(-16,16),random(-16,16),random(8,16),0,0,1)
+		TNT1 A 0 a_bossdeath
 		MANO JJJJJ 6 A_SpawnItemEx("BlackSmoke",random(-16,16),random(-16,16),random(8,16),0,0,1)
 		MANO JJJJJ 9 A_SpawnItemEx("BlackSmoke",random(-16,16),random(-16,16),random(8,16),0,0,1)
 		MANO JJJJJ 12 A_SpawnItemEx("BlackSmoke",random(-16,16),random(-16,16),random(8,16),0,0,1)
-		MANO J -1 a_bossdeath
+		MANO J -1
 		stop
 	Raise:
 		TNT1 A 0 A_GiveToChildren("WasGibbed",1)

--- a/DECORATE/MONSTERS/SpiderMastermind.txt
+++ b/DECORATE/MONSTERS/SpiderMastermind.txt
@@ -66,7 +66,8 @@ states
 		goto see
 	
 	death:
-		TNT1 A 0 A_JumpIf(GetCVAR("bdoom_Gibs")==1,"Death.Particles")
+		TNT1 A 0 A_JumpIf(GetCVAR("bdoom_Gibs")==0,2)
+		TNT1 A 0 A_JumpIf(GetCVAR("bdoom_bossgibs")==1,"Death.Particles")
 		SDMA a 20 a_scream
 		SDMA b 5 a_noblocking
 		SDMA c 5

--- a/MENUDEF.txt
+++ b/MENUDEF.txt
@@ -85,6 +85,9 @@ OptionMenu "BDoom_Settings"
 
 	Option "Enhanced gibs & deaths",					"bdoom_gibs", "OnOff", "", 1
 	StaticText " "
+	
+	Option "Enhanced boss deaths",					"bdoom_bossgibs", "OnOff", "", 1
+	StaticText " "
 
 	Option "Enhanced blood",					"bdoom_blood", "OnOff", "", 1
 	StaticText " "

--- a/MENUDEF.txt
+++ b/MENUDEF.txt
@@ -107,6 +107,8 @@ OptionMenu "BDoom_Settings"
 	Option "Explosion shakes", 					"bdoom_shakes", "OnOff", "", 1
 	
 	Option "Monster shadows", 					"bdoom_shadows", "OnOff", "", 1
+	
+	Option "Face on Standard HUD", 				"bdoom_hudface", "OnOff", "", 1
 }
 
 OptionValue "OnOff"

--- a/SBARINFO.txt
+++ b/SBARINFO.txt
@@ -1,328 +1,71 @@
 monospacefonts true, "0";
 
-statusbar normal, forcescaled, 0.75
+statusbar normal, fullscreenoffsets, 0.75
 {
-AspectRatio "4:3"
+	//LEFT SIDE
+	drawimage "BDSTBL",	0,	 -74; 
+	//HUD face
+	IfCVarInt "bdoom_hudface", 1
 	{
-	drawimage "BDSTBL",	0,	 126;
-	drawimage "BDSTBR",	260, 126;
-
+		drawselectedinventory alternateonempty, INDEXFONT, 53, -32
+		{
+			drawmugshot "STF", 5, 53, -32;
+		}
+	}
 	//armor
-	drawnumber 3, HUDFONT_DOOM, green, armor, 	48, 140, 0, grey,0, 		blue, 101;
+	drawnumber 3, HUDFONT_DOOM, untranslated, armor, 	48, -60, 0;
 	//health
-	drawnumber 3, HUDFONT_DOOM, yellow, health,	48, 172, 0, red,25, 	green, 75;
-	//current ammo
+	drawnumber 3, HUDFONT_DOOM, untranslated, health,	48, -28, 0;
+	//secrets counter
+	drawnumber 3, INDEXFONT_DOOM, untranslated, secrets, 		43, -72;
+	drawnumber 3, INDEXFONT_DOOM, untranslated, totalsecrets, 	55, -72;
+	
+	//RIGHT SIDE
+	drawimage "BDSTBR",	-60, -74;
+	//current ammo on equipped weapon
 	WeaponAmmo Clip
 	{
-		InInventory Backpack || BD_Backpack
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 304, 140,0,	red,50,	green, 200;
-		}
-		else
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 304, 140,0,	red,20,	green, 100;
-		}
+		drawnumber 3, HUDFONT_DOOM, untranslated, ammo1, -16, -60,0;
 	}
 	WeaponAmmo Shell
 	{
-		InInventory Backpack || BD_Backpack
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 304, 140,0,	red,16,	green, 50;
-		}
-		else
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 304, 140,0,	red,8,	green, 20;
-		}
+		drawnumber 3, HUDFONT_DOOM, untranslated, ammo1, -16, -60,0;
 	}
 	WeaponAmmo RocketAmmo
 	{
-		InInventory Backpack || BD_Backpack
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 304, 140,0,	red,10,	green, 40;
-		}
-		else
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 304, 140,0,	red,5,	green, 20;
-		}
+		drawnumber 3, HUDFONT_DOOM, untranslated, ammo1, -16, -60,0;
 	}
 	WeaponAmmo Cell
 	{
-		InInventory Backpack || BD_Backpack
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 304, 140,0,	red,80,	green, 300;
-		}
-		else
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 304, 140,0,	red,40,	green, 150;
-		}
+		drawnumber 3, HUDFONT_DOOM, untranslated, ammo1, -16, -60,0;
 	}
-
-	//secrets counter
-	drawnumber 3, INDEXFONT_DOOM, yellow, secrets, 		44, 128;
-	drawnumber 3, INDEXFONT_DOOM, yellow, totalsecrets, 	56, 128;
 	//kills counter
-	drawnumber 4, INDEXFONT_DOOM, yellow, kills, 		299,128;
-	drawnumber 4, INDEXFONT_DOOM, yellow, Monsters, 	319, 128;
-
+	drawnumber 4, INDEXFONT_DOOM, untranslated, kills, 		-21, -72;
+	drawnumber 4, INDEXFONT_DOOM, untranslated, Monsters, 	-1, -72;
+	//currect ammo
+	drawnumber 3, INDEXFONT_DOOM, untranslated, ammo(Clip), 		-25, -27;
+	drawnumber 3, INDEXFONT_DOOM, untranslated, ammo(Shell), 		-25, -21;
+	drawnumber 3, INDEXFONT_DOOM, untranslated, ammo(RocketAmmo), 	-25, -15;
+	drawnumber 3, INDEXFONT_DOOM, untranslated, ammo(Cell), 		-25, -9;
+	//max ammo
+	drawnumber 3, INDEXFONT_DOOM, untranslated, ammocapacity(Clip), 		-2, -27;
+	drawnumber 3, INDEXFONT_DOOM, untranslated, ammocapacity(Shell), 		-2, -21;
+	drawnumber 3, INDEXFONT_DOOM, untranslated, ammocapacity(RocketAmmo), 	-2, -15;
+	drawnumber 3, INDEXFONT_DOOM, untranslated, ammocapacity(Cell), 		-2, -9;
 	//keys
-	drawswitchableimage keyslot 2 && 5, "nullimage", "STKEYS0", "STKEYS3", "STKEYS6", 310, 139;
-	drawswitchableimage keyslot 3 && 6, "nullimage", "STKEYS1", "STKEYS4", "STKEYS7", 310, 149;
-	drawswitchableimage keyslot 1 && 4, "nullimage", "STKEYS2", "STKEYS5", "STKEYS8", 310, 159;
-
-	//ammo
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammo(Clip), 		295, 173;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammo(Shell), 		295, 179;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammo(RocketAmmo), 	295, 185;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammo(Cell), 		295, 191;
-
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammocapacity(Clip), 		318, 173;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammocapacity(Shell), 		318, 179;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammocapacity(RocketAmmo), 	318, 185;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammocapacity(Cell), 		318, 191;
-	}
-
-AspectRatio "5:4"
-	{
-	drawimage "BDSTBL",	0,	 126;
-	drawimage "BDSTBR",	260, 126;
-
-	//armor
-	drawnumber 3, HUDFONT_DOOM, green, armor, 	48, 140, 0, grey,0, 		blue, 101;
-	//health
-	drawnumber 3, HUDFONT_DOOM, yellow, health,	48, 172, 0, red,25, 	green, 75;
-	//current ammo
-	WeaponAmmo Clip
-	{
-		InInventory Backpack || BD_Backpack
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 304, 140,0,	red,50,	green, 200;
-		}
-		else
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 304, 140,0,	red,20,	green, 100;
-		}
-	}
-	WeaponAmmo Shell
-	{
-		InInventory Backpack || BD_Backpack
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 304, 140,0,	red,16,	green, 50;
-		}
-		else
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 304, 140,0,	red,8,	green, 20;
-		}
-	}
-	WeaponAmmo RocketAmmo
-	{
-		InInventory Backpack || BD_Backpack
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 304, 140,0,	red,10,	green, 40;
-		}
-		else
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 304, 140,0,	red,5,	green, 20;
-		}
-	}
-	WeaponAmmo Cell
-	{
-		InInventory Backpack || BD_Backpack
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 304, 140,0,	red,80,	green, 300;
-		}
-		else
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 304, 140,0,	red,40,	green, 150;
-		}
-	}
-
-	//secrets counter
-	drawnumber 3, INDEXFONT_DOOM, yellow, secrets, 		44, 128;
-	drawnumber 3, INDEXFONT_DOOM, yellow, totalsecrets, 	56, 128;
-
-	//kills counter
-	drawnumber 4, INDEXFONT_DOOM, yellow, kills, 		299,128;
-	drawnumber 4, INDEXFONT_DOOM, yellow, Monsters, 	319, 128;
-
-	//ammo
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammo(Clip), 		295, 173;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammo(Shell), 		295, 179;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammo(RocketAmmo), 	295, 185;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammo(Cell), 		295, 191;
-
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammocapacity(Clip), 		318, 173;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammocapacity(Shell), 		318, 179;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammocapacity(RocketAmmo), 	318, 185;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammocapacity(Cell), 		318, 191;
-	}
-
-AspectRatio "16:9"
-	{
-	drawimage "BDSTBL",	-53, 126;
-	drawimage "BDSTBR",	313, 126;
-
-	//armor
-	drawnumber 3, HUDFONT_DOOM, green, armor, 	-5, 140, 0,	grey,0, 		blue, 101;
-	//drawimage "STTPRCNT", -12, 140;
-	//health
-	drawnumber 3, HUDFONT_DOOM, yellow, health, -5, 172, 0, red,25, 	green, 75;
-	//drawimage "STTPRCNT", -12, 175;
-
-	//current ammo
-	WeaponAmmo Clip
-	{
-		InInventory Backpack || BD_Backpack
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 357, 140,0,	red,50,	green, 200;
-		}
-		else
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 357, 140,0,	red,20,	green, 100;
-		}
-	}
-	WeaponAmmo Shell
-	{
-		InInventory Backpack || BD_Backpack
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 357, 140,0,	red,16,	green, 50;
-		}
-		else
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 357, 140,0,	red,8,	green, 20;
-		}
-	}
-	WeaponAmmo RocketAmmo
-	{
-		InInventory Backpack || BD_Backpack
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 357, 140,0,	red,10,	green, 40;
-		}
-		else
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 357, 140,0,	red,5,	green, 20;
-		}
-	}
-	WeaponAmmo Cell
-	{
-		InInventory Backpack || BD_Backpack
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 357, 140,0,	red,80,	green, 300;
-		}
-		else
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 357, 140,0,	red,40,	green, 150;
-		}
-	}
-
-	//secrets counter
-	drawnumber 3, INDEXFONT_DOOM, yellow, secrets, 		-10, 128;
-	drawnumber 3, INDEXFONT_DOOM, yellow, totalsecrets, 	2, 128;
-	//kills counter
-	drawnumber 4, INDEXFONT_DOOM, yellow, kills, 		352, 128;
-	drawnumber 4, INDEXFONT_DOOM, yellow, Monsters, 	372, 128;
-
-	//keys
-	drawswitchableimage keyslot 2 && 5, "nullimage", "STKEYS0", "STKEYS3", "STKEYS6", 363, 139;
-	drawswitchableimage keyslot 3 && 6, "nullimage", "STKEYS1", "STKEYS4", "STKEYS7", 363, 149;
-	drawswitchableimage keyslot 1 && 4, "nullimage", "STKEYS2", "STKEYS5", "STKEYS8", 363, 159;
-
-	//ammo
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammo(Clip), 		348, 173;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammo(Shell), 		348, 179;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammo(RocketAmmo),	348, 185;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammo(Cell), 		348, 191;
-
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammocapacity(Clip), 		371, 173;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammocapacity(Shell), 		371, 179;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammocapacity(RocketAmmo), 	371, 185;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammocapacity(Cell), 		371, 191;
-	}
-
-AspectRatio "16:10"
-	{
-	drawimage "BDSTBL",	-34,	 126;
-	drawimage "BDSTBR",	292, 126;
-
-	//armor
-	drawnumber 3, HUDFONT_DOOM, green, armor, 14, 140, 0,	grey,0, 		blue, 101;
-	//health
-	drawnumber 3, HUDFONT_DOOM, yellow, health, 14, 172, 0, red,25, 	green, 75;
-	//current ammo
-	WeaponAmmo Clip
-	{
-		InInventory Backpack || BD_Backpack
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 336, 140,0,	red,50,	green, 200;
-		}
-		else
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 336, 140,0,	red,20,	green, 100;
-		}
-	}
-	WeaponAmmo Shell
-	{
-		InInventory Backpack || BD_Backpack
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 336, 140,0,	red,16,	green, 50;
-		}
-		else
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 336, 140,0,	red,8,	green, 20;
-		}
-	}
-	WeaponAmmo RocketAmmo
-	{
-		InInventory Backpack || BD_Backpack
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 336, 140,0,	red,10,	green, 40;
-		}
-		else
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 336, 140,0,	red,5,	green, 20;
-		}
-	}
-	WeaponAmmo Cell
-	{
-		InInventory Backpack || BD_Backpack
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 336, 140,0,	red,80,	green, 300;
-		}
-		else
-		{
-			drawnumber 3, HUDFONT_DOOM, yellow, ammo1, 336, 140,0,	red,40,	green, 150;
-		}
-	}
-
-	//secrets counter
-	drawnumber 3, INDEXFONT_DOOM, yellow, secrets, 		11, 128;
-	drawnumber 3, INDEXFONT_DOOM, yellow, totalsecrets, 	23, 128;
-	//kills counter
-	drawnumber 4, INDEXFONT_DOOM, yellow, kills, 		330,128;
-	drawnumber 4, INDEXFONT_DOOM, yellow, Monsters, 	350, 128;
-
-	//keys
-	drawswitchableimage keyslot 2 && 5, "nullimage", "STKEYS0", "STKEYS3", "STKEYS6", 341, 139;
-	drawswitchableimage keyslot 3 && 6, "nullimage", "STKEYS1", "STKEYS4", "STKEYS7", 341, 149;
-	drawswitchableimage keyslot 1 && 4, "nullimage", "STKEYS2", "STKEYS5", "STKEYS8", 341, 159;
-
-	//ammo
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammo(Clip), 		326, 173;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammo(Shell), 		326, 179;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammo(RocketAmmo), 	326, 185;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammo(Cell), 		326, 191;
-
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammocapacity(Clip), 		349, 173;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammocapacity(Shell), 		349, 179;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammocapacity(RocketAmmo), 	349, 185;
-	drawnumber 3, INDEXFONT_DOOM, yellow, ammocapacity(Cell), 		349, 191;
-	}
+	drawswitchableimage keyslot 2 && 5, "nullimage", "STKEYS0", "STKEYS3", "STKEYS6", -10, -61;
+	drawswitchableimage keyslot 3 && 6, "nullimage", "STKEYS1", "STKEYS4", "STKEYS7", -10, -51;
+	drawswitchableimage keyslot 1 && 4, "nullimage", "STKEYS2", "STKEYS5", "STKEYS8", -10, -41;
 }
 
 statusbar fullscreen, fullscreenoffsets // ZDoom HUD
 {
 
     //health
-	drawmugshot "STF", 5, 12, -60;
+	drawselectedinventory alternateonempty, INDEXFONT, 12, -60
+	{
+		drawmugshot "STF", 5, 12, -60;
+	}
 
     drawnumber 3, HUDFONT_DOOM, green, health, drawshadow, 50, -20, 	0, red,0, 		blue, 101;
 

--- a/Z_BDoom/PlasmaRifle.txt
+++ b/Z_BDoom/PlasmaRifle.txt
@@ -127,7 +127,7 @@ states
 		PLGF AB 4 bright;
 		PLGF C 5 bright {
 			A_GunFlash("Flash3");
-			A_RailAttack(25*random(10,25),0,1,"none","0",RGF_NOPIERCING,2,"PlasmaRailPuff",0,0,0,0,0,0,"PlasmaRailBall");
+			A_RailAttack(25*random(10,25),0,1,"","0",RGF_NOPIERCING,2,"PlasmaRailPuff",0,0,0,0,0,0,"PlasmaRailBall");
 			}
 		PLGC BCD 1 {
 			If(bdoom_weapons == 1)
@@ -572,9 +572,9 @@ States
 			A_SetScale(0.14*randompick(-1,1),0.14*randompick(-1,1));
 			}
 		PEXP CDEFGH 1 bright {
-			A_CustomRailGun(0,0,"none","0",RGF_SILENT|RGF_NOPIERCING|RGF_CENTERZ,0,4,"MPlasmaBallRayPuff",random(0,360),random(0,360),32,64,0,0,"MPlasmaBallRay");
-			A_CustomRailGun(0,0,"none","0",RGF_SILENT|RGF_NOPIERCING|RGF_CENTERZ,0,4,"MPlasmaBallRayPuff",random(0,360),random(0,360),32,64,0,0,"MPlasmaBallRay");
-			A_CustomRailGun(0,0,"none","0",RGF_SILENT|RGF_NOPIERCING|RGF_CENTERZ,0,4,"MPlasmaBallRayPuff",random(0,360),random(0,360),32,64,0,0,"MPlasmaBallRay");
+			A_CustomRailGun(0,0,"","0",RGF_SILENT|RGF_NOPIERCING|RGF_CENTERZ,0,4,"MPlasmaBallRayPuff",random(0,360),random(0,360),32,64,0,0,"MPlasmaBallRay");
+			A_CustomRailGun(0,0,"","0",RGF_SILENT|RGF_NOPIERCING|RGF_CENTERZ,0,4,"MPlasmaBallRayPuff",random(0,360),random(0,360),32,64,0,0,"MPlasmaBallRay");
+			A_CustomRailGun(0,0,"","0",RGF_SILENT|RGF_NOPIERCING|RGF_CENTERZ,0,4,"MPlasmaBallRayPuff",random(0,360),random(0,360),32,64,0,0,"MPlasmaBallRay");
 			}
 		PEXP IJKLM 1 bright;
 		stop;
@@ -603,7 +603,7 @@ renderstyle "none";
 states
 	{
 	Spawn:
-		TNT1 A 0 NoDelay A_CustomRailGun(0,0,"none","0",RGF_SILENT|RGF_NOPIERCING|RGF_CENTERZ|RGF_EXPLICITANGLE,0,3.0,"MPlasmaBallRayPuff",180,0,4,0,0,0,"MPlasmaBallTrailRay");
+		TNT1 A 0 NoDelay A_CustomRailGun(0,0,"","0",RGF_SILENT|RGF_NOPIERCING|RGF_CENTERZ|RGF_EXPLICITANGLE,0,3.0,"MPlasmaBallRayPuff",180,0,4,0,0,0,"MPlasmaBallTrailRay");
 		stop;
 	}
 }

--- a/Z_BDoom/SpriteShadow.zc
+++ b/Z_BDoom/SpriteShadow.zc
@@ -101,6 +101,9 @@ class Z_Shadow : Z_SpriteShadowBase
 		// clean-up
 		if (ownerRef && ownerRef.CountInv("Z_ShadeMe") <= 0) Destroy();
 		if (!ownerRef) Destroy();
+
+		CVAR shadows = CVar.FindCVar('bdoom_shadows');
+		if (!shadows || shadows && !shadows.GetInt()) Destroy();
 	}
 }
 
@@ -119,7 +122,8 @@ class Z_ShadeMe : CustomInventory
 
 	override void Tick(void)
 	{
-		if (!sr && Owner)
+		CVAR shadows = CVar.FindCVar('bdoom_shadows');
+		if (!sr && Owner && (!shadows || shadows && shadows.GetInt()) )
 		{
 			// spawn the shadow
 			Actor sh = Spawn("Z_Shadow", Owner.Pos, NO_REPLACE);

--- a/Z_BDoom/bd_blood.txt
+++ b/Z_BDoom/bd_blood.txt
@@ -197,7 +197,7 @@ states
 	{
 	spawn:
 		TNT1 A 0 NoDelay A_CheckSight("Null");
-		TNT1 A 0 A_SetScale(scalex*randompick(-1,1)*frandom(1.0,1.3),scaley*frandom(1.0,1.3));
+		TNT1 A 0 A_SetScale(scale.x*randompick(-1,1)*frandom(1.0,1.3),scale.y*frandom(1.0,1.3));
 		BLOD UVWWXXYYY 2;
 		TNT1 A 0 {
 			bNOGRAVITY = false;
@@ -235,7 +235,7 @@ states
 			if (bdoom_blood == 0 || waterlevel > 0)
 				self.destroy();
 			}
-		TNT1 A 0 A_SetScale(scalex*randompick(-1,1)*frandom(1.0,1.3),scaley*frandom(1.0,1.3));
+		TNT1 A 0 A_SetScale(scale.x*randompick(-1,1)*frandom(1.0,1.3),scale.y*frandom(1.0,1.3));
 		BLOD XYZ 3;
 		TNT1 A 0 {
 			bNOGRAVITY = false;

--- a/Z_BDoom/fist.txt
+++ b/Z_BDoom/fist.txt
@@ -12,7 +12,6 @@ bool bpunch; //(with Berserk) used left punch?
 int targetdistance;
 int jangle; //jump angle
 Default {
-	inventory.icon "none";
 	weapon.selectionorder 370;
 	+WEAPON.NOALERT
 	weapon.slotnumber 1;
@@ -1081,7 +1080,7 @@ Class ModernBerserk_Speed : PowerSpeed
 Default {
 	powerup.duration -40;
 	speed 1.3;
-	powerup.color "none";
+	powerup.color "00 00 00";
 	}
 }
 
@@ -1091,6 +1090,6 @@ Default {
 	+NOPAIN;
 	powerup.duration -40;
 	Damagefactor 0.5;
-	powerup.color "none";
+	powerup.color "00 00 00";
 	}
 }


### PR DESCRIPTION
All warnings have been silenced, except for BD_BFGBall error on dynamic lights (this is because the BFG is not in ZScript yet, this will be fixed automatically once you port it).
Fixed an issue involving Mancubus/Arachnotron deaths.
Simplified Standard HUD Code. 
Made shadows able to be toggled. 
Bosses enhanced deaths can now be toggled separately from standard enhanced gibs.

All these commits are independent of each other, so comment if you don't want a particular commit/need something changed.

