### PR TITLE
Allow Scythe 2 MAP16 to be completed without freelook

### DIFF
--- a/ZScript.txt
+++ b/ZScript.txt
@@ -4,6 +4,7 @@ version "4.0.0"
 #include "Z_Bdoom/bd_blood.zc"
 #include "Z_Bdoom/bd_gibs.zc"
 #include "Z_BDoom/bd_events.zc"
+#include "Z_BDoom/bd_levelcomp.zc"
 
 #include "Z_Bdoom/bd_weapon.zc"
 #include "Z_Bdoom/mk_matrix.zsc"

--- a/Z_BDoom/bd_levelcomp.zc
+++ b/Z_BDoom/bd_levelcomp.zc
@@ -1,0 +1,19 @@
+class BD_LevelCompatibility : LevelCompatibility
+{
+	protected void Apply(name checksum, string mapname)
+	{
+		switch(checksum)
+		{
+			case 'F14C31EF1503A3C94C8633595D2F7778': // Scythe 2 MAP16
+			{
+				//The TERRAIN lump in Beautiful Doom prevents this map from being completed without freelook.
+				//Simply lower the switch a couple of units to fix this problem.
+				OffsetSectorPlane(26, Sector.Floor,   -2);
+				OffsetSectorPlane(26, Sector.Ceiling, -2);
+				//Lower the other switch for visual consistency
+				OffsetSectorPlane(27, Sector.Floor,   -2);
+				OffsetSectorPlane(27, Sector.Ceiling, -2);
+			}
+		}
+	}
+}


### PR DESCRIPTION
When using Beautiful Doom on Scythe 2, MAP16 can no longer be completed without freelook because the player clips into the the floor in the starting room (due to the TERRAIN lump), and will be too low to hit the switch to leave the room. Since this is an extreme corner case, and Scythe 2 is a widely-played mapset, rather than change anything in Beautiful Doom, it's better to simply modify the map itself using level compatibility. In this case, the switch in question is simply lowered 2 units (along with the switch next to it for visual consistency).